### PR TITLE
fix(collector/tx): duplicate tx

### DIFF
--- a/src/collector/block/tx.ts
+++ b/src/collector/block/tx.ts
@@ -204,7 +204,12 @@ async function generateTxEntities(txHashes: string[], height: string, block: Blo
   // pulling all txs from hash
   const taxInfo = await getTaxRateAndCap(height)
 
-  return Bluebird.map(txHashes, (txHash) => generateLcdTransactionToTxEntity(txHash, block, taxInfo))
+  // txs with the same tx hash may appear more than once in the same block duration
+  // take unique of txHashes
+  // TODO: do this without using Set
+  const txHashesUnique = [...new Set(txHashes)]
+
+  return Bluebird.map(txHashesUnique, (txHash) => generateLcdTransactionToTxEntity(txHash, block, taxInfo))
 }
 
 export async function collectTxs(


### PR DESCRIPTION
[Block 7549547 on mainnet](https://lcd.terra.dev/blocks/7549547) contains duplicate txs (txHash: 27DD29EE9EB19B1BBEB4785233C2D92092E6221700EBBF88C3E76421B193D04D), which would lead to creating  SQL that violates the unique constraint

The fix is safe as the transaction would be processed exactly once (because of account sequencing).